### PR TITLE
Expose `crypto_generichash`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # sodium-chloride
 
-polyfil to adapt [sodium-friends](https://github.com/sodium-friends) api to [chloride](https://github.com/dominictarr/chloride)
+polyfill to adapt [sodium-friends](https://github.com/sodium-friends) api to [chloride](https://github.com/dominictarr/chloride)
 
 ## TODO
 
-* `*box_open*` methods arn't passing yet.
+* `*box_open*` methods are not passing yet.
 * sodium-friends needs a PR to add key conversions.
 
 ## License

--- a/index.js
+++ b/index.js
@@ -105,6 +105,12 @@ module.exports = function (na) {
     return hash
   }
 
+  exports.crypto_generichash = function (ptxt, length, key) {
+    var hash = Z(length || na.crypto_generichash_BYTES);
+    na.crypto_generichash(hash, ptxt, key)
+    return hash
+  }
+
   exports.crypto_hash_sha256 = function (ptxt) {
     var hash = Z(na.crypto_hash_sha256_BYTES)
     na.crypto_hash_sha256(hash, ptxt)
@@ -142,4 +148,3 @@ module.exports = function (na) {
 
   return exports
 }
-


### PR DESCRIPTION
Exposes `crypto_generichash` to allow use of the blake2b hashing algorithm with arbitrary length and optional key.