### PR TITLE
use Buffer.alloc instead of constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 
 function Z(n) {
-  return new Buffer(n)
+  return Buffer.alloc(n)
 }
 
 module.exports = function (na) {


### PR DESCRIPTION
`new Buffer` in recent versions of Node.js causes some deprecation logic and warnings to run, and this times 100k means a noticeable hit. Changing to the non-deprecated `Buffer.alloc` means there is no check for deprecation, and in ssb-db2 benchmarks this shaved off 330ms from the total run of the benchmark.

cc @arj03

(not sure if Dominic will do something about this repo, maybe could transfer it to ssbc?)